### PR TITLE
Fix code scanning alert no. 24: Resource injection

### DIFF
--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -21,7 +21,10 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public SqliteDbProvider(ConfigFile configFile)
         {
-            _connectionString = string.Format("Data Source={0};Version=3", configFile.Get(DbConstants.KEY_FILE_NAME));
+            var builder = new SqliteConnectionStringBuilder();
+            builder.DataSource = configFile.Get(DbConstants.KEY_FILE_NAME);
+            builder.Version = 3;
+            _connectionString = builder.ConnectionString;
 
             _clientExec = configFile.Get(DbConstants.KEY_CLIENT_EXEC);
             _dbFileName = configFile.Get(DbConstants.KEY_FILE_NAME);

--- a/WebGoat/App_Code/DB/SqliteDbProvider.cs
+++ b/WebGoat/App_Code/DB/SqliteDbProvider.cs
@@ -289,7 +289,7 @@ namespace OWASP.WebGoat.NET.App_Code.DB
 
         public string UpdateCustomerPassword(int customerNumber, string password)
         {
-            string sql = "update CustomerLogin set password = '" + Encoder.Encode(password) + "' where customerNumber = " + customerNumber;
+            string sql = "update CustomerLogin set password = @password where customerNumber = @customerNumber";
             string output = null;
             try
             {
@@ -299,6 +299,8 @@ namespace OWASP.WebGoat.NET.App_Code.DB
                     connection.Open();
 
                     SqliteCommand command = new SqliteCommand(sql, connection);
+                    command.Parameters.AddWithValue("@password", Encoder.Encode(password));
+                    command.Parameters.AddWithValue("@customerNumber", customerNumber);
                 
                     int rows_added = command.ExecuteNonQuery();
                     


### PR DESCRIPTION
Fixes [https://github.com/jose-salazar-webjet/ghas-demo-csharp/security/code-scanning/24](https://github.com/jose-salazar-webjet/ghas-demo-csharp/security/code-scanning/24)

To fix the problem, we should use a connection string builder class to construct the connection string safely. This approach ensures that user input is properly escaped and does not alter the meaning of the connection string. Specifically, we will use the `SqliteConnectionStringBuilder` class to construct the connection string.

1. Replace the direct construction of the connection string with the `SqliteConnectionStringBuilder` class.
2. Update the `_connectionString` assignment in the `SqliteDbProvider` constructor to use the builder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
